### PR TITLE
updated lame, speaker versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
   "dependencies": {
     "async": "^0.9.0",
     "home": "^0.1.3",
-    "lame": "1.2.2",
-    "speaker": "0.2.6",
+    "lame": "^1.2.2",
+    "speaker": "^0.2.6",
     "pool_stream": "0.0.2",
     "underscore": "~1.6.0"
   },


### PR DESCRIPTION
was getting compile errors in lame and speaker with node 4.0, gcc 4.8.4
on ubuntu 14.04.   updating the versions helped

(I think lame needs to be 1.2.3, in addition to your change for speaker 0.2.6)