### PR TITLE
Fix fail to build when node version is v6.0.0 or later. close #60

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "follow-redirects": "0.0.7",
     "home": "^0.1.3",
     "keypress": "^0.2.1",
-    "lame": "^1.2.2",
+    "lame": "^1.2.4",
     "pcm-volume": "^1.0.0",
     "pool_stream": "0.0.2",
     "speaker": "^0.2.6",


### PR DESCRIPTION
Fixes #60

- update lame (1.2.2 -> 1.2.4)
